### PR TITLE
Broadcast support clean up. Multiple changes.

### DIFF
--- a/src/main/scala/org/apache/spark/broadcast/CrailBroadcast.scala
+++ b/src/main/scala/org/apache/spark/broadcast/CrailBroadcast.scala
@@ -95,7 +95,7 @@ private object CrailBroadcast {
 
   //FIXME: (atr) I am not completely sure about if this gives us the best performance.
   val broadcastCache:mutable.HashMap[Long, Option[Any]] = new mutable.HashMap[Long, Option[Any]]
-  private val useLocalCache = CrailStore.get.useBroadcastLocalCache
+  private val useLocalCache = true
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit = {
     this.synchronized {

--- a/src/main/scala/org/apache/spark/broadcast/CrailBroadcastFactory.scala
+++ b/src/main/scala/org/apache/spark/broadcast/CrailBroadcastFactory.scala
@@ -34,9 +34,12 @@ class CrailBroadcastFactory extends BroadcastFactory {
     new CrailBroadcast[T](value_, id)
   }
 
-  override def stop() { }
+  override def stop(): Unit = {
+    CrailBroadcast.cleanCache()
+  }
 
-  override def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean) {
+  override def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit = {
+    CrailBroadcast.unbroadcast(id, removeFromDriver, blocking)
   }
 }
 


### PR DESCRIPTION
(1) Broadcast files and opened and closed properly. No
    pending buffered streams linger till the end.
(2) Broadcast values can now be cached locally instead
    in the local BlockManager.
    Use 'spark.crail.broadcast.useLocalMap' true|false
(3) Broadcast has its own serializer now. Currently it
    only catches the case of Array[Byte], but it will be
    expanded gradually.