### PR TITLE
FIX: delete old shuffle stages which are indexed on shuffleID

### DIFF
--- a/src/main/scala/org/apache/spark/storage/CrailDispatcher.scala
+++ b/src/main/scala/org/apache/spark/storage/CrailDispatcher.scala
@@ -424,7 +424,7 @@ class CrailDispatcher () extends Logging {
   def registerShuffle(shuffleId: Int, numMaps: Int, partitions: Int) : Unit = {
     //    logInfo("registering shuffle " + shuffleId + ", time " + ", cacheSize " + fs.getCacheSize)
     unregisterShuffle(shuffleId - shuffleCycle)
-    if (shuffleCache.contains(shuffleId)){
+    if (shuffleCache.containsKey(shuffleId)){
       return
     }
 
@@ -457,7 +457,7 @@ class CrailDispatcher () extends Logging {
   def unregisterShuffle(shuffleId: Int) : Unit = {
     try {
       if (shuffleId >= 0){
-        if (!shuffleCache.contains(shuffleId)){
+        if (!shuffleCache.containsKey(shuffleId)){
           return
         }
         val shuffleIdDir = shuffleDir + "/shuffle_" + shuffleId


### PR DESCRIPTION
The old code uses, "contains" which is the same as "containsValue"
however the shuffleID is the key, which should be lookedup using
"containsKey". See here for more details:

https://github.com/zrlio/crail-spark-io/issues/4

Signed-off-by: Animesh Trivedi <atrivedi@apache.org>